### PR TITLE
Add view commands for contacts and journal entries

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,6 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_DATE_FORMAT = "Invalid date format!\n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX = "The entry index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -11,8 +11,8 @@ public abstract class ViewCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Views the person or entry by the "
             + "index number used in the displayed list."
-            + "\nParameters: in/SCOPE (must be \"c\" or  \"j\") INDEX (must be a positive integer)"
-            + "\nExample: " + COMMAND_WORD + " in/c" + " 1";
+            + "\nParameters: in/SCOPE (must be \"c\" or  \"j\") index/INDEX (must be a positive integer)"
+            + "\nExample: " + COMMAND_WORD + " in/c" + " index/1";
 
     protected final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+public abstract class ViewCommand extends Command {
+    public static final String COMMAND_WORD = "view";
+
+    public static final String MESSAGE_VIEW_SUCCESS = "View %1$s: %2$s";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Views the person or entry by the "
+            + "index number used in the displayed list."
+            + "\nParameters: in/SCOPE (must be \"c\" or  \"j\") INDEX (must be a positive integer)"
+            + "\nExample: " + COMMAND_WORD + " in/c" + " 1";
+
+    protected final Index targetIndex;
+
+    public ViewCommand(Index index) {
+        this.targetIndex = index;
+    }
+
+    @Override
+    public abstract CommandResult execute(Model model) throws CommandException;
+
+    @Override
+    public abstract boolean equals(Object other);
+}

--- a/src/main/java/seedu/address/logic/commands/ViewJournalEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewJournalEntryCommand.java
@@ -37,6 +37,7 @@ public class ViewJournalEntryCommand extends ViewCommand {
 
     @Override
     public boolean equals(Object other) {
-        return false;
+        return other == this || (other instanceof ViewJournalEntryCommand
+                && ((ViewJournalEntryCommand) other).targetIndex.equals(targetIndex));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewJournalEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewJournalEntryCommand.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.journal.Entry;
+
+/**
+ * Views journal entry at specified index of the list currently displayed.
+ */
+public class ViewJournalEntryCommand extends ViewCommand {
+
+    public ViewJournalEntryCommand(Index targetIndex) {
+        super(targetIndex);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Entry> lastShownList = model.getFilteredEntryList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(
+                    Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+        }
+
+        Entry entryToView = lastShownList.get(targetIndex.getZeroBased());
+        model.updateFilteredEntryList(entry -> entry.isSameEntry(entryToView));
+
+        return new CommandResult(String.format(MESSAGE_VIEW_SUCCESS, "entry", entryToView.toString()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return false;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ViewPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewPersonCommand.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Views a person at specified index in the current list displayed.
+ */
+public class ViewPersonCommand extends ViewCommand {
+
+    public ViewPersonCommand(Index targetIndex) {
+        super(targetIndex);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(
+                    Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToView = lastShownList.get(targetIndex.getZeroBased());
+        model.updateFilteredPersonList(person -> person.isSamePerson(personToView));
+
+        return new CommandResult(String.format(MESSAGE_VIEW_SUCCESS, "person", personToView.toString()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return false;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ViewPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewPersonCommand.java
@@ -37,6 +37,7 @@ public class ViewPersonCommand extends ViewCommand {
 
     @Override
     public boolean equals(Object other) {
-        return false;
+        return other == this || (other instanceof ViewPersonCommand
+                && ((ViewPersonCommand) other).targetIndex.equals(targetIndex));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -91,6 +92,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ViewCommand.COMMAND_WORD:
+            return new ViewCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,5 +15,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
     public static final Prefix PREFIX_TITLE = new Prefix("n/");
     public static final Prefix PREFIX_SCOPE = new Prefix("in/");
+    public static final Prefix PREFIX_INDEX = new Prefix("index/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -14,5 +14,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_DATE_AND_TIME = new Prefix("at/");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
     public static final Prefix PREFIX_TITLE = new Prefix("n/");
+    public static final Prefix PREFIX_SCOPE = new Prefix("in/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -127,11 +127,17 @@ public class ParserUtil {
         return tagSet;
     }
 
+    /**
+     * Parses string into scope.
+     * @param scope a string specified a certain scope
+     * @return "c" if it's address book scope or "j" for journal scope
+     * @throws ParseException if the string is not "c" or "j" throws exception
+     */
     public static String parseScope(String scope) throws ParseException {
         requireNonNull(scope);
         String trimmedScope = scope.trim();
-        if (scope.equals("c") || scope.equals("j")) {
-            return scope;
+        if (trimmedScope.equals("c") || trimmedScope.equals("j")) {
+            return trimmedScope;
         } else {
             throw new ParseException("Scope can only be \"c\" or \"j\".");
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -126,4 +126,14 @@ public class ParserUtil {
         }
         return tagSet;
     }
+
+    public static String parseScope(String scope) throws ParseException {
+        requireNonNull(scope);
+        String trimmedScope = scope.trim();
+        if (scope.equals("c") || scope.equals("j")) {
+            return scope;
+        } else {
+            throw new ParseException("Scope can only be \"c\" or \"j\".");
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -1,7 +1,10 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SCOPE;
+
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ViewCommand;
@@ -9,36 +12,29 @@ import seedu.address.logic.commands.ViewJournalEntryCommand;
 import seedu.address.logic.commands.ViewPersonCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-import java.util.stream.Stream;
-
 /**
  * Parses input arguments and creates a new ViewCommand object
  */
 public class ViewCommandParser implements Parser<ViewCommand> {
     @Override
     public ViewCommand parse(String args) throws ParseException {
-        String scope, index;
-        try {
-            scope = args.substring(0, args.lastIndexOf(" "));
-            index = args.substring(args.lastIndexOf(" ")+1);
-        } catch (Exception e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
-        }
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(scope, PREFIX_SCOPE);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SCOPE, PREFIX_INDEX);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_SCOPE)|| !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_SCOPE, PREFIX_INDEX) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
         }
 
-        Index targetIndex = parseIndex(index);
+        Index targetIndex = parseIndex(argMultimap.getValue(PREFIX_INDEX).get());
+        String scope = ParserUtil.parseScope(argMultimap.getValue(PREFIX_SCOPE).get());
 
-        switch (ParserUtil.parseScope(argMultimap.getValue(PREFIX_SCOPE).get())) {
-            case "c":
-                return new ViewPersonCommand(targetIndex);
-            case "j":
-                return new ViewJournalEntryCommand(targetIndex);
+        switch (scope) {
+        case "c":
+            return new ViewPersonCommand(targetIndex);
+        case "j":
+            return new ViewJournalEntryCommand(targetIndex);
+        default:
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
         }
-        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
     }
 
     private Index parseIndex(String arg) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SCOPE;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ViewCommand;
@@ -8,26 +9,36 @@ import seedu.address.logic.commands.ViewJournalEntryCommand;
 import seedu.address.logic.commands.ViewPersonCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
+import java.util.stream.Stream;
+
 /**
  * Parses input arguments and creates a new ViewCommand object
  */
 public class ViewCommandParser implements Parser<ViewCommand> {
     @Override
     public ViewCommand parse(String args) throws ParseException {
-        String[] arg = args.trim().split(" ");
-        String scope = arg[0];
-        String index = arg[1];
-        if (scope.startsWith("in/")) {
-            if (scope.equals("in/c")) {
-                return new ViewPersonCommand(parseIndex(index));
-            } else if (scope.equals("in/j")) {
-                return new ViewJournalEntryCommand(parseIndex(index));
-            } else {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
-            }
-        } else {
+        String scope, index;
+        try {
+            scope = args.substring(0, args.lastIndexOf(" "));
+            index = args.substring(args.lastIndexOf(" ")+1);
+        } catch (Exception e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
         }
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(scope, PREFIX_SCOPE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_SCOPE)|| !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+        }
+
+        Index targetIndex = parseIndex(index);
+
+        switch (ParserUtil.parseScope(argMultimap.getValue(PREFIX_SCOPE).get())) {
+            case "c":
+                return new ViewPersonCommand(targetIndex);
+            case "j":
+                return new ViewJournalEntryCommand(targetIndex);
+        }
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
     }
 
     private Index parseIndex(String arg) throws ParseException {
@@ -42,5 +53,13 @@ public class ViewCommandParser implements Parser<ViewCommand> {
                     pe
             );
         }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ViewCommand;
+import seedu.address.logic.commands.ViewJournalEntryCommand;
+import seedu.address.logic.commands.ViewPersonCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ViewCommand object
+ */
+public class ViewCommandParser implements Parser<ViewCommand> {
+    @Override
+    public ViewCommand parse(String args) throws ParseException {
+        String[] arg = args.trim().split(" ");
+        String scope = arg[0];
+        String index = arg[1];
+        if (scope.startsWith("in/")) {
+            if (scope.equals("in/c")) {
+                return new ViewPersonCommand(parseIndex(index));
+            } else if (scope.equals("in/j")) {
+                return new ViewJournalEntryCommand(parseIndex(index));
+            } else {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+            }
+        } else {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+        }
+    }
+
+    private Index parseIndex(String arg) throws ParseException {
+        try {
+            return ParserUtil.parseIndex(arg);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(
+                            MESSAGE_INVALID_COMMAND_FORMAT,
+                            ViewCommand.MESSAGE_USAGE
+                    ),
+                    pe
+            );
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -118,4 +118,6 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    void updateFilteredEntryList(Predicate<Entry> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -166,6 +166,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void updateFilteredEntryList(Predicate<Entry> predicate) {
+        requireNonNull(predicate);
+        filteredEntries.setPredicate(predicate);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         // short circuit if same object
         if (obj == this) {

--- a/src/test/java/seedu/address/logic/commands/AddContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactCommandTest.java
@@ -216,6 +216,11 @@ public class AddContactCommandTest {
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void updateFilteredEntryList(Predicate<Entry> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddJournalEntryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddJournalEntryCommandTest.java
@@ -216,6 +216,11 @@ class AddJournalEntryCommandTest {
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void updateFilteredEntryList(Predicate<Entry> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**


### PR DESCRIPTION
Usage: 
`view in/SCOPE index/INDEX`.
Shows the person/entry at the specified index in the current displayed list.

Parameters:
1. `SCOPE` must be `c` or `j` (additional whitespaces allowed)
1. `INDEX` must be a positive integer.