### PR TITLE
Bug fixes about card selection in list panels and its content view

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -90,7 +90,9 @@ IntelliJournal:
 
 #### Adding a contact: `addcontact`
 
-Adds a contact to the address book.
+Adds a contact to the address book, after adding the contact, the app will show the
+`Contacts` tab, and the sidebar will scroll to the new contact you just added,
+displaying contact information on the right.
 
 Aliases: `addcontact`, `addc`
 
@@ -131,6 +133,9 @@ Format: `editc INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
   of tags is not cumulative.
 * You can remove all the person’s tags by typing t/ without specifying any tags
   after it.
+* After editing a contact, the list displayed in the `Contacts` tab will be reset
+to show all existing contacts, because the previous filtering operation may not
+still have the same effects on the edited contact.
 
 Examples:
 
@@ -204,7 +209,9 @@ Format: `clearc`
 
 #### Adding a journal entry: `addjournal`
 
-Adds a journal entry to the journal.
+Adds a journal entry to the journal. After adding the journal entry, the app will
+move to the `Journal` tab, scrolling to the entry you just added, displaying the
+information of that entry on the right.
 
 Aliases: `addjournal`, `addj`
 
@@ -251,6 +258,9 @@ Format: `editj INDEX n/NAME [at/DATE_AND_TIME] [d/DESCRIPTION]
   of tags is not cumulative.
 * You can remove all the entry's tags by typing t/ without specifying any tags
   after it.
+* After editing a journal entry, the list displayed in the `Journal` tab will be
+  reset to show all existing contacts, because the previous filtering operation may
+  not still have the same effects on the edited contact.
 
 #### Viewing a journal entry: `view in/j`
 

--- a/src/main/java/seedu/address/logic/commands/AddContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactCommand.java
@@ -58,7 +58,9 @@ public class AddContactCommand extends Command {
         }
 
         model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd)).setAddressBookTab();
+
+        int index = model.getFilteredPersonList().indexOf(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd)).setAddressBookTab().setViewingPerson(index);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactCommand.java
@@ -59,8 +59,8 @@ public class AddContactCommand extends Command {
 
         model.addPerson(toAdd);
 
-        int index = model.getFilteredPersonList().indexOf(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd)).setAddressBookTab().setViewingPerson(index);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd))
+            .setAddressBookTab().setViewingPerson(toAdd);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddJournalEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddJournalEntryCommand.java
@@ -88,8 +88,9 @@ public class AddJournalEntryCommand extends Command {
         }
 
         model.addEntry(validToAdd);
+        int index = model.getFilteredEntryList().indexOf(validToAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, validToAdd))
-                .setJournalTab();
+                .setJournalTab().setViewingJournal(index);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddJournalEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddJournalEntryCommand.java
@@ -88,9 +88,8 @@ public class AddJournalEntryCommand extends Command {
         }
 
         model.addEntry(validToAdd);
-        int index = model.getFilteredEntryList().indexOf(validToAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, validToAdd))
-                .setJournalTab().setViewingJournal(index);
+                .setJournalTab().setViewingJournal(validToAdd);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -25,6 +25,7 @@ public class CommandResult {
     private boolean isChangingTheme = false;
     private boolean isViewingPerson = false;
     private int indexPersonToView = 0;
+    private int indexEntryToView = 0;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
@@ -105,8 +106,9 @@ public class CommandResult {
         return this;
     }
 
-    public CommandResult setViewingJournal() {
+    public CommandResult setViewingJournal(int indexEntryToView) {
         this.isViewingJournal = true;
+        this.indexEntryToView = indexEntryToView;
         return this;
     }
 
@@ -145,6 +147,11 @@ public class CommandResult {
     public int getIndexPersonToView() {
         assert (isViewingPerson);
         return indexPersonToView;
+    }
+
+    public int getIndexEntryToView() {
+        assert (isViewingJournal);
+        return indexEntryToView;
     }
 
     public boolean isCleaningJournalView() {

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import seedu.address.model.journal.Entry;
+import seedu.address.model.person.Person;
+
 /**
  * Represents the result of a command execution.
  */
@@ -24,8 +27,8 @@ public class CommandResult {
     private boolean isCleaningJournalView = false;
     private boolean isChangingTheme = false;
     private boolean isViewingPerson = false;
-    private int indexPersonToView = 0;
-    private int indexEntryToView = 0;
+    private Person personToView = null;
+    private Entry entryToView = null;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
@@ -106,15 +109,15 @@ public class CommandResult {
         return this;
     }
 
-    public CommandResult setViewingJournal(int indexEntryToView) {
+    public CommandResult setViewingJournal(Entry entryToView) {
         this.isViewingJournal = true;
-        this.indexEntryToView = indexEntryToView;
+        this.entryToView = entryToView;
         return this;
     }
 
-    public CommandResult setViewingPerson(int indexPersonToView) {
+    public CommandResult setViewingPerson(Person personToView) {
         this.isViewingPerson = true;
-        this.indexPersonToView = indexPersonToView;
+        this.personToView = personToView;
         return this;
     }
 
@@ -144,14 +147,14 @@ public class CommandResult {
         return isViewingPerson;
     }
 
-    public int getIndexPersonToView() {
+    public Person getPersonToView() {
         assert (isViewingPerson);
-        return indexPersonToView;
+        return personToView;
     }
 
-    public int getIndexEntryToView() {
+    public Entry getEntryToView() {
         assert (isViewingJournal);
-        return indexEntryToView;
+        return entryToView;
     }
 
     public boolean isCleaningJournalView() {

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -23,6 +23,8 @@ public class CommandResult {
     private boolean isViewingJournal = false;
     private boolean isCleaningJournalView = false;
     private boolean isChangingTheme = false;
+    private boolean isViewingPerson = false;
+    private int indexPersonToView = 0;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
@@ -108,6 +110,12 @@ public class CommandResult {
         return this;
     }
 
+    public CommandResult setViewingPerson(int indexPersonToView) {
+        this.isViewingPerson = true;
+        this.indexPersonToView = indexPersonToView;
+        return this;
+    }
+
     public CommandResult setCleaningJournalView(boolean isCleaningJournalView) {
         this.isCleaningJournalView = isCleaningJournalView;
         return this;
@@ -128,6 +136,15 @@ public class CommandResult {
 
     public boolean isViewingJournal() {
         return isViewingJournal;
+    }
+
+    public boolean isViewingPerson() {
+        return isViewingPerson;
+    }
+
+    public int getIndexPersonToView() {
+        assert (isViewingPerson);
+        return indexPersonToView;
     }
 
     public boolean isCleaningJournalView() {

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -90,7 +90,7 @@ public class EditContactCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+//        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(
                 String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -90,7 +89,7 @@ public class EditContactCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-//        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        // model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(
                 String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -91,7 +91,8 @@ public class EditContactCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         // model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(
-                String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
+                String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson))
+                .setViewingPerson(editedPerson);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -89,7 +90,7 @@ public class EditContactCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-        // model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(
                 String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson))
                 .setViewingPerson(editedPerson);

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -90,7 +90,7 @@ public class EditContactCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(
                 String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson))
                 .setViewingPerson(editedPerson);

--- a/src/main/java/seedu/address/logic/commands/EditJournalEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditJournalEntryCommand.java
@@ -60,7 +60,7 @@ public class EditJournalEntryCommand extends Command {
     private final EditEntryDescriptor editEntryDescriptor;
 
     /**
-     * @param index
+     * @param index the index of journal entry to edit
      */
     public EditJournalEntryCommand(Index index,
                                    EditEntryDescriptor editEntryDescriptor) {
@@ -129,7 +129,7 @@ public class EditJournalEntryCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_ENTRY);
         }
         model.setEntry(entryToEdit, editedEntry);
-        model.updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
+//        model.updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
 
         return new CommandResult(
                 String.format(MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry))

--- a/src/main/java/seedu/address/logic/commands/EditJournalEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditJournalEntryCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE_AND_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ENTRIES;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -128,7 +129,7 @@ public class EditJournalEntryCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_ENTRY);
         }
         model.setEntry(entryToEdit, editedEntry);
-        // model.updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
+        model.updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
 
         return new CommandResult(
                 String.format(MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry))

--- a/src/main/java/seedu/address/logic/commands/EditJournalEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditJournalEntryCommand.java
@@ -132,7 +132,8 @@ public class EditJournalEntryCommand extends Command {
 
         return new CommandResult(
                 String.format(MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry))
-                .setJournalTab();
+                .setJournalTab()
+                .setViewingJournal(editedEntry);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditJournalEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditJournalEntryCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE_AND_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ENTRIES;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -129,7 +128,7 @@ public class EditJournalEntryCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_ENTRY);
         }
         model.setEntry(entryToEdit, editedEntry);
-//        model.updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
+        // model.updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
 
         return new CommandResult(
                 String.format(MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry))

--- a/src/main/java/seedu/address/logic/commands/ViewJournalEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewJournalEntryCommand.java
@@ -39,7 +39,7 @@ public class ViewJournalEntryCommand extends ViewCommand {
                         "entry",
                         entryToView.toString()
                 )
-        ).setJournalTab().setViewingJournal(targetIndex.getZeroBased());
+        ).setJournalTab().setViewingJournal(entryToView);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ViewJournalEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewJournalEntryCommand.java
@@ -31,7 +31,7 @@ public class ViewJournalEntryCommand extends ViewCommand {
         }
 
         Entry entryToView = lastShownList.get(targetIndex.getZeroBased());
-//        model.updateFilteredEntryList(entry -> entry.isSameEntry(entryToView));
+        // model.updateFilteredEntryList(entry -> entry.isSameEntry(entryToView));
 
         return new CommandResult(
                 String.format(

--- a/src/main/java/seedu/address/logic/commands/ViewJournalEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewJournalEntryCommand.java
@@ -31,7 +31,7 @@ public class ViewJournalEntryCommand extends ViewCommand {
         }
 
         Entry entryToView = lastShownList.get(targetIndex.getZeroBased());
-        model.updateFilteredEntryList(entry -> entry.isSameEntry(entryToView));
+//        model.updateFilteredEntryList(entry -> entry.isSameEntry(entryToView));
 
         return new CommandResult(
                 String.format(
@@ -39,7 +39,7 @@ public class ViewJournalEntryCommand extends ViewCommand {
                         "entry",
                         entryToView.toString()
                 )
-        ).setJournalTab().setViewingJournal();
+        ).setJournalTab().setViewingJournal(targetIndex.getZeroBased());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ViewPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewPersonCommand.java
@@ -31,7 +31,7 @@ public class ViewPersonCommand extends ViewCommand {
         }
 
         Person personToView = lastShownList.get(targetIndex.getZeroBased());
-        model.updateFilteredPersonList(person -> person.isSamePerson(personToView));
+//        model.updateFilteredPersonList(person -> person.isSamePerson(personToView));
 
         return new CommandResult(
                 String.format(
@@ -39,7 +39,7 @@ public class ViewPersonCommand extends ViewCommand {
                         "contact",
                         personToView.toString()
                 )
-        ).setAddressBookTab();
+        ).setAddressBookTab().setViewingPerson(targetIndex.getZeroBased());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ViewPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewPersonCommand.java
@@ -31,7 +31,7 @@ public class ViewPersonCommand extends ViewCommand {
         }
 
         Person personToView = lastShownList.get(targetIndex.getZeroBased());
-//        model.updateFilteredPersonList(person -> person.isSamePerson(personToView));
+        // model.updateFilteredPersonList(person -> person.isSamePerson(personToView));
 
         return new CommandResult(
                 String.format(

--- a/src/main/java/seedu/address/logic/commands/ViewPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewPersonCommand.java
@@ -39,7 +39,7 @@ public class ViewPersonCommand extends ViewCommand {
                         "contact",
                         personToView.toString()
                 )
-        ).setAddressBookTab().setViewingPerson(targetIndex.getZeroBased());
+        ).setAddressBookTab().setViewingPerson(personToView);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/EntryContent.java
+++ b/src/main/java/seedu/address/ui/EntryContent.java
@@ -55,7 +55,7 @@ public class EntryContent extends UiPart<Region> {
     public EntryContent() {
         super(FXML);
         this.entry = null;
-//        this.calendar.setImage(getImage("/images/calendar_1.png"));
+        // this.calendar.setImage(getImage("/images/calendar_1.png"));
         emptyRelatedListText.getStyleClass().add("text-empty-list");
         relatedPersonListView.setCellFactory(listView -> new PersonListViewCell());
         setDefaultContent();

--- a/src/main/java/seedu/address/ui/EntryContent.java
+++ b/src/main/java/seedu/address/ui/EntryContent.java
@@ -55,7 +55,7 @@ public class EntryContent extends UiPart<Region> {
     public EntryContent() {
         super(FXML);
         this.entry = null;
-        this.calendar.setImage(getImage("/images/calendar_1.png"));
+//        this.calendar.setImage(getImage("/images/calendar_1.png"));
         emptyRelatedListText.getStyleClass().add("text-empty-list");
         relatedPersonListView.setCellFactory(listView -> new PersonListViewCell());
         setDefaultContent();
@@ -66,14 +66,16 @@ public class EntryContent extends UiPart<Region> {
     }
 
     private void setDefaultContent() {
+        this.calendar.setImage(null);
         title.setText("");
-        relatedListPane.getChildren().setAll(emptyRelatedListText);
+        relatedListPane.getChildren().setAll(new Text(""));
         description.setText("Please select a Journal Entry...");
         date.setText("");
         tags.getChildren().clear();
     }
 
     private void setContent(Entry entry) {
+        this.calendar.setImage(getImage("/images/calendar_1.png"));
         title.setText(entry.getTitle().title);
         if (entry.getContactList().isEmpty()) {
             relatedListPane.getChildren().setAll(emptyRelatedListText);

--- a/src/main/java/seedu/address/ui/EntryListPanel.java
+++ b/src/main/java/seedu/address/ui/EntryListPanel.java
@@ -55,6 +55,7 @@ public class EntryListPanel extends UiPart<Region> {
 
     public void select(int index) {
         entryListView.getSelectionModel().select(index);
+        entryListView.scrollTo(index);
     }
     //@@author
 

--- a/src/main/java/seedu/address/ui/EntryListPanel.java
+++ b/src/main/java/seedu/address/ui/EntryListPanel.java
@@ -53,6 +53,10 @@ public class EntryListPanel extends UiPart<Region> {
         return entryListView.getItems();
     }
 
+    /**
+     * Selects the item in the entry list at specified index.
+     * @param index the index of item to be selected
+     */
     public void select(int index) {
         entryListView.getSelectionModel().select(index);
         entryListView.scrollTo(index);

--- a/src/main/java/seedu/address/ui/EntryListPanel.java
+++ b/src/main/java/seedu/address/ui/EntryListPanel.java
@@ -61,6 +61,16 @@ public class EntryListPanel extends UiPart<Region> {
         entryListView.getSelectionModel().select(index);
         entryListView.scrollTo(index);
     }
+
+    /**
+     * Selects the first item if nothing is selected.
+     */
+    public void select() {
+        if (entryListView.getSelectionModel().getSelectedItems().isEmpty()) {
+            entryListView.getSelectionModel().selectFirst();
+            entryListView.scrollTo(0);
+        }
+    }
     //@@author
 
     /**

--- a/src/main/java/seedu/address/ui/EntryListPanel.java
+++ b/src/main/java/seedu/address/ui/EntryListPanel.java
@@ -52,6 +52,10 @@ public class EntryListPanel extends UiPart<Region> {
     public ObservableList<Entry> getEntryListItems() {
         return entryListView.getItems();
     }
+
+    public void select(int index) {
+        entryListView.getSelectionModel().select(index);
+    }
     //@@author
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -250,6 +250,7 @@ public class MainWindow extends UiPart<Stage> {
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
             CommandResult commandResult = logic.execute(commandText);
+            entryListPanel.select();
             logger.info("Execute result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -250,6 +250,7 @@ public class MainWindow extends UiPart<Stage> {
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
             CommandResult commandResult = logic.execute(commandText);
+            personListPanel.select();
             entryListPanel.select();
             logger.info("Execute result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -275,7 +275,8 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             if (commandResult.isViewingJournal()) {
-                handleViewingJournal();
+                int index = commandResult.getIndexEntryToView();
+                entryListPanel.select(index);
             }
 
             if (commandResult.isCleaningJournalView()) {
@@ -308,10 +309,6 @@ public class MainWindow extends UiPart<Stage> {
         SingleSelectionModel<Tab> selectionModel = tabPane.getSelectionModel();
         int selectedIndex = selectionModel.getSelectedIndex();
         selectionModel.select((selectedIndex + 1) % 3);
-    }
-
-    private void handleViewingJournal() {
-        entryContent.setEntryContentToUser(logic.getFilteredEntryList().get(0));
     }
 
     private void handleCleaningJournalView() {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -21,6 +21,8 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.journal.Entry;
+import seedu.address.model.person.Person;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -270,13 +272,13 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             if (commandResult.isViewingPerson()) {
-                int index = commandResult.getIndexPersonToView();
-                personListPanel.select(index);
+                Person personToView = commandResult.getPersonToView();
+                personListPanel.select(logic.getFilteredPersonList().indexOf(personToView));
             }
 
             if (commandResult.isViewingJournal()) {
-                int index = commandResult.getIndexEntryToView();
-                entryListPanel.select(index);
+                Entry entryToView = commandResult.getEntryToView();
+                entryListPanel.select(logic.getFilteredEntryList().indexOf(entryToView));
             }
 
             if (commandResult.isCleaningJournalView()) {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -269,6 +269,11 @@ public class MainWindow extends UiPart<Stage> {
                 }
             }
 
+            if (commandResult.isViewingPerson()) {
+                int index = commandResult.getIndexPersonToView();
+                personListPanel.select(index);
+            }
+
             if (commandResult.isViewingJournal()) {
                 handleViewingJournal();
             }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -63,6 +63,16 @@ public class PersonListPanel extends UiPart<Region> {
         personListView.getSelectionModel().select(index);
         personListView.scrollTo(index);
     }
+
+    /**
+     * Selects the first item if nothing is being selected.
+     */
+    public void select() {
+        if (personListView.getSelectionModel().getSelectedItems().isEmpty()) {
+            personListView.getSelectionModel().selectFirst();
+            personListView.scrollTo(0);
+        }
+    }
     //@@author
 
     //@@author {Nauw1010}

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -57,6 +57,7 @@ public class PersonListPanel extends UiPart<Region> {
 
     public void select(int index) {
         personListView.getSelectionModel().select(index);
+        personListView.scrollTo(index);
     }
     //@@author
 

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -55,6 +55,10 @@ public class PersonListPanel extends UiPart<Region> {
         return personListView.getItems();
     }
 
+    /**
+     * Selects the item in the list of specified index.
+     * @param index the index of the item to be selected
+     */
     public void select(int index) {
         personListView.getSelectionModel().select(index);
         personListView.scrollTo(index);

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -54,6 +54,10 @@ public class PersonListPanel extends UiPart<Region> {
     public ObservableList<Person> getPersonListItems() {
         return personListView.getItems();
     }
+
+    public void select(int index) {
+        personListView.getSelectionModel().select(index);
+    }
     //@@author
 
     //@@author {Nauw1010}

--- a/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
@@ -182,7 +182,7 @@ public class EditContactCommandTest {
                             new UserPrefs(),
                             new AliasMap()
                     );
-            expectedModel.updateFilteredPersonList(person -> model.getFilteredPersonList().contains(person));
+
             expectedModel.setPerson(
                     model.getFilteredPersonList().get(0),
                     editedPerson

--- a/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
@@ -182,6 +182,7 @@ public class EditContactCommandTest {
                             new UserPrefs(),
                             new AliasMap()
                     );
+            expectedModel.updateFilteredPersonList(person -> model.getFilteredPersonList().contains(person));
             expectedModel.setPerson(
                     model.getFilteredPersonList().get(0),
                     editedPerson

--- a/src/test/java/seedu/address/logic/commands/EditJournalEntryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditJournalEntryCommandTest.java
@@ -173,7 +173,6 @@ public class EditJournalEntryCommandTest {
                             new Journal(model.getJournal()),
                             new UserPrefs(),
                             new AliasMap());
-            showEntryAtIndex(expectedModel, INDEX_FIRST_PERSON);
             expectedModel.setEntry(model.getFilteredEntryList().get(0), editedEntry);
             assertCommandSuccess(
                     editJournalEntryCommand,

--- a/src/test/java/seedu/address/logic/commands/EditJournalEntryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditJournalEntryCommandTest.java
@@ -173,6 +173,7 @@ public class EditJournalEntryCommandTest {
                             new Journal(model.getJournal()),
                             new UserPrefs(),
                             new AliasMap());
+            showEntryAtIndex(expectedModel, INDEX_FIRST_PERSON);
             expectedModel.setEntry(model.getFilteredEntryList().get(0), editedEntry);
             assertCommandSuccess(
                     editJournalEntryCommand,


### PR DESCRIPTION
1. The `view` command no longer filtered the list, instead it directly selects the card chosen to view, and the list scroll bar will also scrolls to the position of that card, same behavior for the rest changes below.
1. After `add` commands, the item that is added will be selected to view.
1. After `edit` commands, the item that is edited will be selected to view.