### PR TITLE
Fix duplicate name persons

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactCommand.java
@@ -53,7 +53,7 @@ public class AddContactCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasPerson(toAdd)) {
+        if (model.hasPerson(toAdd) || model.hasName(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/address/logic/commands/AddContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactCommand.java
@@ -12,6 +12,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 //@@author {zhXchD}
+
 /**
  * Adds a person to the address book.
  */
@@ -38,6 +39,8 @@ public class AddContactCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON =
             "This person already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_NAME =
+            "This name already exists in the address book.";
 
     private final Person toAdd;
 
@@ -53,14 +56,17 @@ public class AddContactCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasPerson(toAdd) || model.hasName(toAdd)) {
+        if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+        if (model.hasName(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_NAME);
         }
 
         model.addPerson(toAdd);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd))
-            .setAddressBookTab().setViewingPerson(toAdd);
+                .setAddressBookTab().setViewingPerson(toAdd);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -85,9 +85,11 @@ public class EditContactCommand extends Command {
                 personToEdit, editPersonDescriptor);
 
         if (!personToEdit.isSamePerson(editedPerson)
-                && model.hasPerson(editedPerson)) {
+                && (model.hasPerson(editedPerson) || model.hasName(editedPerson))) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
+
+
 
         model.setPerson(personToEdit, editedPerson);
         model.updateJournalContacts(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -54,6 +54,8 @@ public class EditContactCommand extends Command {
             "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON =
             "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_NAME =
+            "This name already exists in the address book.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -84,11 +86,12 @@ public class EditContactCommand extends Command {
         Person editedPerson = createEditedPerson(
                 personToEdit, editPersonDescriptor);
 
-        if (!personToEdit.isSamePerson(editedPerson)
-                && (model.hasPerson(editedPerson) || model.hasName(editedPerson))) {
+        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
-
+        if (model.hasName(editedPerson)) {
+            throw new CommandException(MESSAGE_DUPLICATE_NAME);
+        }
 
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -54,8 +54,6 @@ public class EditContactCommand extends Command {
             "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON =
             "This person already exists in the address book.";
-    public static final String MESSAGE_DUPLICATE_NAME =
-            "This name already exists in the address book.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -88,9 +86,6 @@ public class EditContactCommand extends Command {
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
-        }
-        if (model.hasName(editedPerson)) {
-            throw new CommandException(MESSAGE_DUPLICATE_NAME);
         }
 
 

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -54,6 +54,8 @@ public class EditContactCommand extends Command {
             "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON =
             "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_NAME =
+            "This name already exists in the address book.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -84,10 +86,14 @@ public class EditContactCommand extends Command {
         Person editedPerson = createEditedPerson(
                 personToEdit, editPersonDescriptor);
 
+        if (!personToEdit.hasSameName(editedPerson)
+                && model.hasName(editedPerson)) {
+            // Name has been changed, need to check if new name is a duplicate
+            throw new CommandException(MESSAGE_DUPLICATE_NAME);
+        }
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
-
 
         model.setPerson(personToEdit, editedPerson);
         model.updateJournalContacts(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -67,6 +67,15 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if a person with the same name as {@code person} exists in
+     * the address book.
+     */
+    public boolean hasName(Person person) {
+        requireNonNull(person);
+        return persons.containsName(person);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -92,6 +92,12 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns true if a person with the same name as {@code person} exists
+     * in the address book.
+     */
+    boolean hasName(Person person);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -127,6 +127,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasName(Person person) {
+        requireNonNull(person);
+        return addressBook.hasName(person);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         requireNonNull(target);
         addressBook.removePerson(target);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -78,7 +78,7 @@ public class Person {
     /**
      * Returns true if both persons have the same name.
      */
-    public boolean hasSameName(Person otherPerson)  {
+    public boolean hasSameName(Person otherPerson) {
         if (otherPerson == this) {
             return true;
         }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -76,6 +76,18 @@ public class Person {
     }
 
     /**
+     * Returns true if both persons have the same name.
+     */
+    public boolean hasSameName(Person otherPerson)  {
+        if (otherPerson == this) {
+            return true;
+        }
+
+        return otherPerson != null
+                && otherPerson.getName().equals(getName());
+    }
+
+    /**
      * Returns true if both persons of the same name have at least one other identity field that is the same.
      * This defines a weaker notion of equality between two persons.
      */

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -49,10 +49,11 @@ public class UniquePersonList implements Iterable<Person> {
     /**
      * Adds a person to the list.
      * The person must not already exist in the list.
+     * The name must also not already exist in the list.
      */
     public void add(Person toAdd) {
         requireNonNull(toAdd);
-        if (contains(toAdd)) {
+        if (contains(toAdd) || containsName(toAdd)) {
             throw new DuplicatePersonException();
         }
         internalList.add(toAdd);

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -38,6 +38,15 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Returns true if the list contains a person with the same name as the
+     * given argument.
+     */
+    public boolean containsName(Person toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::hasSameName);
+    }
+
+    /**
      * Adds a person to the list.
      * The person must not already exist in the list.
      */

--- a/src/test/java/seedu/address/logic/commands/AddAliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddAliasCommandTest.java
@@ -189,6 +189,11 @@ public class AddAliasCommandTest {
         }
 
         @Override
+        public boolean hasName(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddContactCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactCommandIntegrationTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -37,7 +38,9 @@ public class AddContactCommandIntegrationTest {
         @Test
         @DisplayName("should successfully add new person")
         public void execute_newPerson_success() {
-            Person validPerson = new PersonBuilder().build();
+            Person validPerson = new PersonBuilder()
+                    .withName(VALID_NAME_AMY)
+                    .build();
 
             Model expectedModel = new ModelManager(
                     model.getAddressBook(), new Journal(), new UserPrefs(), new AliasMap());

--- a/src/test/java/seedu/address/logic/commands/AddContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactCommandTest.java
@@ -191,6 +191,11 @@ public class AddContactCommandTest {
         }
 
         @Override
+        public boolean hasName(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddContactCommandTest.java
@@ -303,6 +303,12 @@ public class AddContactCommandTest {
         }
 
         @Override
+        public boolean hasName(Person person) {
+            requireNonNull(person);
+            return personsAdded.stream().anyMatch(person::hasSameName);
+        }
+
+        @Override
         public void addPerson(Person person) {
             requireNonNull(person);
             personsAdded.add(person);

--- a/src/test/java/seedu/address/logic/commands/AddJournalEntryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddJournalEntryCommandTest.java
@@ -100,6 +100,11 @@ class AddJournalEntryCommandTest {
         }
 
         @Override
+        public boolean hasName(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/DeleteAliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteAliasCommandTest.java
@@ -179,6 +179,11 @@ public class DeleteAliasCommandTest {
         }
 
         @Override
+        public boolean hasName(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
@@ -269,7 +269,7 @@ public class EditContactCommandTest {
             assertCommandFailure(
                     editContactCommand,
                     model,
-                    EditContactCommand.MESSAGE_DUPLICATE_PERSON
+                    EditContactCommand.MESSAGE_DUPLICATE_NAME
             );
         }
 
@@ -291,7 +291,7 @@ public class EditContactCommandTest {
             assertCommandFailure(
                     editContactCommand,
                     model,
-                    EditContactCommand.MESSAGE_DUPLICATE_PERSON
+                    EditContactCommand.MESSAGE_DUPLICATE_NAME
             );
         }
 

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -61,6 +61,38 @@ public class UniquePersonListTest {
     }
 
     @Nested
+    @DisplayName("containsName method")
+    class ContainsName {
+        @Test
+        @DisplayName("should throw NullPointerException")
+        public void containsName_nullPerson_throwsNullPointerException() {
+            assertThrows(NullPointerException.class, () ->
+                    uniquePersonList.containsName(null));
+        }
+
+        @Test
+        @DisplayName("should return false if name not in list")
+        public void contains_personNotInList_returnsFalse() {
+            // sample contact with all fields
+            assertFalse(uniquePersonList.containsName(ALICE));
+
+            // sample contact with only name
+            assertFalse(uniquePersonList.containsName(
+                    new PersonBuilder()
+                            .setBlankFields()
+                            .build()
+            ));
+        }
+
+        @Test
+        @DisplayName("should return true if name in list")
+        public void contains_personInList_returnsTrue() {
+            uniquePersonList.add(ALICE);
+            assertTrue(uniquePersonList.containsName(ALICE));
+        }
+    }
+
+    @Nested
     @DisplayName("add method")
     class Add {
         @Test
@@ -78,6 +110,19 @@ public class UniquePersonListTest {
             assertThrows(DuplicatePersonException.class, () ->
                     uniquePersonList.add(ALICE));
         }
+
+        @Test
+        @DisplayName("should throw DuplicatePersonException if name is "
+                + "already in the list")
+        public void add_duplicateName_throwsDuplicatePersonException() {
+            uniquePersonList.add(ALICE);
+            assertThrows(DuplicatePersonException.class, () ->
+                    uniquePersonList.add(
+                            new PersonBuilder()
+                                    .setBlankFields()
+                                    .build()));
+        }
+
     }
 
     @Nested


### PR DESCRIPTION
AddContactCommand has a new message for duplicated names. It's similar to the message for duplicate persons, but I think this distinction helps users figure out that names have to be unique.

Instead of modifying the previous isSamePerson method in Person, this has a new hasSameName method that only checks for name equality rather than same name + some other same identity field. It's possible that isSamePerson can simply be replaced by hasSameName, but for now this approach works without possibly breaking other test cases. Similarly, the duplicate person message may be deprecated since that uses a stricter form of equality than duplicate names, so AFAIK it's not actually possible to trigger the duplicate person message anymore. 

Will need to check UG/DG again to update any inconsistencies and possibly add sections about how duplicate names aren't allowed. 

Closes #186 .
