### PR TITLE
Fix name case duplicate

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -117,6 +117,7 @@ Format: `addcontact n/NAME [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
 :bulb: **Tips:**<br>
 
 * A contact can have any number of tags (including 0).
+* `NAME` must not be a name that is already used in the address book, even if it has different case letters.
 * `TAG` must be alphanumeric, without spaces.
 * `PHONE_NUMBER` must be a valid Singaporean number, 8 digits long and starting with either 6, 8, or 9.
 * The country code +65 is also accepted at the start of `PHONE_NUMBER`.
@@ -151,6 +152,7 @@ Format: `editc INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…�
 
 * Edits the contact at the specified `INDEX`. The index refers to the index
   number shown in the displayed contact list.
+* `NAME` must not be a name that is already used in the address book, even if it has different case letters.
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
 * `TAG` must be alphanumeric, without spaces.
@@ -291,6 +293,7 @@ Format: `addjournal n/TITLE [at/DATE_AND_TIME] [d/DESCRIPTION]
 
 * A journal entry can have any number of contacts or tags (including 0)
 * `CONTACT_NAME` must be an existing name in the address book.
+* `CONTACT_NAME` is case-insensitive, and does not need to be capitalised to find contacts required.
 * `DATE_AND_TIME` must be in the format: "YYYY-MM-DD HH:MM".
 * `TAG` must be alphanumeric, without spaces.
 
@@ -342,6 +345,7 @@ Format: `editj INDEX [n/TITLE] [at/DATE_AND_TIME] [d/DESCRIPTION]
 
 * Edits the contact at the specified `INDEX`. The index refers to the index
   number shown in the displayed contact list.
+* `CONTACT_NAME` is case-insensitive, and does not need to be capitalised to find contacts required.
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
 * When editing tags, the existing tags of the entry will be removed i.e adding

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -48,7 +48,8 @@ public class Name {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Name // instanceof handles nulls
-                && fullName.equals(((Name) other).fullName)); // state check
+                && fullName.toLowerCase()
+                .equals(((Name) other).fullName.toLowerCase())); // state check
     }
 
     @Override

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.DisplayName;
@@ -55,6 +56,32 @@ public class NameTest {
             assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
             assertTrue(Name.isValidName("Capital Tan")); // with capital letters
             assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        }
+    }
+
+    @Nested
+    @DisplayName("equals method")
+    class equals {
+        @Test
+        @DisplayName("should return true if same object")
+        public void equals_sameObject_true() {
+            Name amy = new Name(VALID_NAME_AMY);
+            assertTrue(amy.equals(amy));
+        }
+
+        @Test
+        @DisplayName("should return true if different case")
+        public void equals_differentCase_true() {
+            Name amy = new Name(VALID_NAME_AMY);
+            Name lowerAmy = new Name(VALID_NAME_AMY.toLowerCase());
+            assertTrue(amy.equals(lowerAmy));
+        }
+
+        @Test
+        @DisplayName("should return false if null")
+        public void equals_null_false() {
+            Name amy = new Name(VALID_NAME_AMY);
+            assertFalse(amy.equals(null));
         }
     }
 }

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -61,7 +61,7 @@ public class NameTest {
 
     @Nested
     @DisplayName("equals method")
-    class equals {
+    class Equals {
         @Test
         @DisplayName("should return true if same object")
         public void equals_sameObject_true() {


### PR DESCRIPTION
Persons with the same name as an existing Person (case-insensitive) can no longer be added. i.e. `David` and `david` are now considered the same name, which will show the duplicate name error.
Similarly, the changed equality check for Name also makes adding or editing journal entries with contacts to be case insensitive, so `editj 1 with/david` can add `David` to the journal entry. 